### PR TITLE
add leads endpoint

### DIFF
--- a/tap_copper/schemas/leads.json
+++ b/tap_copper/schemas/leads.json
@@ -1,0 +1,308 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "prefix": {
+      "type": [
+        "null"
+      ]
+    },
+    "first_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "last_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "middle_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "suffix": {
+      "type": [
+        "null"
+      ]
+    },
+    "address": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "street": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "city": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "state": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "postal_code": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "assignee_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "company_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "customer_source_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "details": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "email": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "email": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "category": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "interaction_count": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "monetary_unit": {
+      "type": [
+        "null"
+      ]
+    },
+    "monetary_value": {
+      "type": [
+        "null"
+      ]
+    },
+    "converted_unit": {
+      "type": [
+        "null"
+      ]
+    },
+    "converted_value": {
+      "type": [
+        "null"
+      ]
+    },
+    "socials": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "url": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "category": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "status_id": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "tags": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "title": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "websites": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "url": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "category": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "phone_numbers": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "number": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "category": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "custom_fields": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "custom_field_definition_id": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          },
+          "value": {
+            "type": [
+              "null",
+              "integer"
+            ]
+          }
+        }
+      }
+    },
+    "date_created": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "date_modified": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "date_last_contacted": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    }
+  }
+}

--- a/tap_copper/streams/__init__.py
+++ b/tap_copper/streams/__init__.py
@@ -1,13 +1,16 @@
 from tap_copper.streams.users import UsersStream
 from tap_copper.streams.people import PeopleStream
+from tap_copper.streams.leads import LeadsStream
 
 
 AVAILABLE_STREAMS = [
     UsersStream,
     PeopleStream,
+    LeadsStream,
 ]
 
 __all__ = [
     'UsersStream',
-    'PeopleStream'
+    'PeopleStream',
+    'LeadsStream',
 ]

--- a/tap_copper/streams/leads.py
+++ b/tap_copper/streams/leads.py
@@ -1,0 +1,15 @@
+from tap_copper.streams.base import BaseStream
+import singer
+
+LOGGER = singer.get_logger()  # noqa
+
+
+class LeadsStream(BaseStream):
+    API_METHOD = 'POST'
+    TABLE = 'leads'
+    KEY_PROPERTIES = ['id']
+
+        
+    @property
+    def path(self):
+        return '/leads/search'


### PR DESCRIPTION
### Changelog
- Add Leads endpoint

### Validation
Singer-Check-Tap
```
(env) 12:05:55 ~/dev/taps/tap-copper (feature/add_leads *%) $ cat out.json | singer-check-tap
Checking stdin for valid Singer-formatted data
The output is valid.
It contained 1698 messages for 3 streams.

      3 schema messages
   1695 record messages
      0 state messages

Details by stream:
+--------+---------+---------+
| stream | records | schemas |
+--------+---------+---------+
| users  | 12      | 1       |
| people | 1523    | 1       |
| leads  | 160     | 1       |
+--------+---------+---------+
```

Target-Stitch
```
(env2) 13:09:37 ~/dev/taps/tap-copper (feature/add_leads %) $ cat out.json | target-stitch -n
INFO users (12): Batch is valid
INFO people (1523): Batch is valid
INFO leads (160): Batch is valid
INFO Exiting normally
```